### PR TITLE
Update awesome-browser-extensions-for-github url

### DIFF
--- a/08-github-FE-project-master/README.md
+++ b/08-github-FE-project-master/README.md
@@ -535,7 +535,7 @@ HTML5
   [73]: https://github.com/peachananr/onepage-scroll
   [74]: http://www.htmleaf.com/Demo/201412311045.html
   [75]: https://github.com/fhopeman/justlazy
-  [76]: https://github.com/stefanbuck/awesome-browser-extensions-for-github
+  [76]: https://stefanbuck.com/awesome-browser-extensions-for-github
   [77]: https://github.com/Polymer/polymer
   [78]: https://github.com/bartaz/impress.js
   [79]: http://bartaz.github.io/impress.js/#/bored


### PR DESCRIPTION
I made an interactive webpage out of this awesome list with the capability sort and filter the extensions which I think is super useful. I link from the repo itself to this domain, but maybe better to point people straight to this version. How does that sound?